### PR TITLE
Format lambda with Prettier + ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
         "no-underscore-dangle": 0,
         "no-unused-vars": 2,
         "no-use-before-define": [2, "nofunc"],
-        "quotes": [1, "single"],
+        "quotes": [1, "double"],
         "semi": 2,
         "keyword-spacing": [2, {"before": true, "after": true}],
         "space-before-function-paren": 1,

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -134,27 +134,15 @@ function putRecordToDynamo({
     {
       TableName: TABLE_NAME,
       Key: {
-        stageName: {
-          S: data.isLive ? "live" : "draft"
-        },
-        frontId: {
-          S: data.front
-        }
+        stageName: { S: data.isLive ? "live" : "draft" },
+        frontId: { S: data.front }
       },
       UpdateExpression: updateExpression,
       ExpressionAttributeValues: {
-        ":count": {
-          N: data.status === "ok" ? "0" : "1"
-        },
-        ":time": {
-          S: isoDate
-        },
-        ":status": {
-          S: data.status
-        },
-        ":message": {
-          S: data.message || data.status
-        }
+        ":count": { N: data.status === "ok" ? "0" : "1" },
+        ":time": { S: isoDate },
+        ":status": { S: data.status },
+        ":message": { S: data.message || data.status }
       },
       ReturnValues: "ALL_NEW"
     },
@@ -202,11 +190,7 @@ function maybeNotifyPressBroken({
     dynamo.getItem(
       {
         TableName: ERRORS_TABLE_NAME,
-        Key: {
-          error: {
-            S: error
-          }
-        }
+        Key: { error: { S: error } }
       },
       (err, data) => {
         if (err) {
@@ -299,22 +283,14 @@ function maybeNotifyPressBroken({
 function getErrorUpdateData(error, affectedFronts, today) {
   return {
     TableName: ERRORS_TABLE_NAME,
-    Key: {
-      error: {
-        S: error
-      }
-    },
+    Key: { error: { S: error } },
     AttributeUpdates: {
       lastSeen: {
-        Value: {
-          N: today.valueOf().toString()
-        },
+        Value: { N: today.valueOf().toString() },
         Action: "PUT"
       },
       affectedFronts: {
-        Value: {
-          SS: affectedFronts
-        },
+        Value: { SS: affectedFronts },
         Action: "PUT"
       }
     }
@@ -328,18 +304,10 @@ function getErrorCreateData(error, today, frontId) {
   return {
     TableName: ERRORS_TABLE_NAME,
     Item: {
-      error: {
-        S: error
-      },
-      ttl: {
-        N: timeToLive.toString()
-      },
-      lastSeen: {
-        N: today.valueOf().toString()
-      },
-      affectedFronts: {
-        SS: [frontId]
-      }
+      error: { S: error },
+      ttl: { N: timeToLive.toString() },
+      lastSeen: { N: today.valueOf().toString() },
+      affectedFronts: { SS: [frontId] }
     }
   };
 }

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,17 +1,17 @@
-import config from '../tmp/config.json';
-import AWS from 'aws-sdk';
-import mapLimit from 'async-es/mapLimit';
-import { post as postUtil } from 'simple-get-promise';
-import errorParser from './util/errorParser';
+import config from "../tmp/config.json";
+import AWS from "aws-sdk";
+import mapLimit from "async-es/mapLimit";
+import { post as postUtil } from "simple-get-promise";
+import errorParser from "./util/errorParser";
 
 AWS.config.region = config.AWS.region;
 
 const ERROR_THRESHOLD = 3;
 const PARALLEL_JOBS = 4;
-const STAGE = (process.env.AWS_LAMBDA_FUNCTION_NAME || 'CODE')
-    .split('-')
-    .filter(token => /(CODE?|PROD?)/.test(token))
-    .pop();
+const STAGE = (process.env.AWS_LAMBDA_FUNCTION_NAME || "CODE")
+  .split("-")
+  .filter(token => /(CODE?|PROD?)/.test(token))
+  .pop();
 const ROLE_TO_ASSUME = config.AWS.roleToAssume[STAGE];
 const TABLE_NAME = config.dynamo[STAGE].tableName;
 const ERRORS_TABLE_NAME = config.dynamo[STAGE].errorsTableName;
@@ -19,258 +19,361 @@ const STALE_ERROR_THRESHOLD_MINUTES = 30;
 const TIME_TO_LIVE_HOURS = 24;
 const MAX_INCIDENT_LENGTH = 250;
 
-export function handler (event, context, callback) {
-    const today = new Date();
-    const sts = new AWS.STS();
+export function handler(event, context, callback) {
+  const today = new Date();
+  const sts = new AWS.STS();
 
-    sts.assumeRole({
-        RoleArn: ROLE_TO_ASSUME,
-        RoleSessionName: 'lambda-assume-role',
-        DurationSeconds: 900
-    }, (err, data) => {
-        if (err) {
-            console.error('Error assuming cross account role', err);
-            callback(err);
-        } else {
-            const stsCredentials = data.Credentials;
-            const assumedCredentials = new AWS.Credentials(
-                stsCredentials.AccessKeyId,
-                stsCredentials.SecretAccessKey,
-                stsCredentials.SessionToken
-            );
-            const dynamo = new AWS.DynamoDB({
-                credentials: assumedCredentials
-            });
-            const lambda = new AWS.Lambda({
-                credentials: assumedCredentials
-            });
-            storeEvents({event, dynamo, lambda, isoDate: today.toISOString(), logger: console, callback, isProd: STAGE === 'PROD', post: postUtil, today: today});
-        }
-    });
-}
-
-export function storeEvents ({event, callback, dynamo, isoDate, logger, post, isProd, today}) {
-    const jobs = { started: 0, completed: 0, total: event.Records.length };
-
-    mapLimit(
-        event.Records,
-        PARALLEL_JOBS,
-        (record, jobCallback) => putRecordToDynamo({jobs, record, dynamo, isoDate, logger, isProd, callback: jobCallback, post, today}),
-        err => {
-            if (err) {
-                logger.error('Error processing records', err);
-                callback(new Error('Error when processing records: ' + err.message));
-            } else {
-                logger.log('DONE');
-                callback(null, 'Processed ' + event.Records.length + ' records.');
-            }
-        }
-    );
-}
-
-function putRecordToDynamo ({jobs, record, dynamo, isoDate, isProd, callback, logger, post, today}) {
-    const jobId = ++jobs.started;
-
-    logger.log('Process job ' + jobId + ' in ' + record.kinesis.sequenceNumber);
-
-    const buffer = new Buffer(record.kinesis.data, 'base64');
-    const data = JSON.parse(buffer.toString('utf8'));
-    const action = {
-        SET: ['actionTime=:time', 'statusCode=:status', 'messageText=:message']
-    };
-    if (data.status === 'ok') {
-        action.SET.push('pressedTime=:time', 'errorCount=:count');
-    } else {
-        action.ADD = ['errorCount :count'];
-    }
-    const updateExpression = Object.keys(action).map(key => `${key} ${action[key].join(', ')}`).join(' ');
-
-    dynamo.updateItem({
-        TableName: TABLE_NAME,
-        Key: {
-            stageName: {
-                S: data.isLive ? 'live' : 'draft'
-            },
-            frontId: {
-                S: data.front
-            }
-        },
-        UpdateExpression: updateExpression,
-        ExpressionAttributeValues: {
-            ':count': {
-                N: data.status === 'ok' ? '0' : '1'
-            },
-            ':time': {
-                S: isoDate
-            },
-            ':status': {
-                S: data.status
-            },
-            ':message': {
-                S: data.message || data.status
-            }
-        },
-        ReturnValues: 'ALL_NEW'
-    }, (err, updatedItem) => {
-        if (err) {
-            logger.error('Error while processing ' + jobId, err);
-            callback(err);
-        } else {
-            maybeNotifyPressBroken({item: updatedItem, logger, isProd, post, dynamo, today, callback});
-        }
-    });
-}
-
-function maybeNotifyPressBroken ({item, logger, isProd, post, dynamo, today, callback}) {
-    const attributes = item ? item.Attributes : {};
-    const errorCount = attributes.errorCount
-        ? parseInt(item.Attributes.errorCount.N, 10) : 0;
-    const error = errorParser.parse(attributes.messageText ? attributes.messageText.S : 'unknown error');
-    const frontId = attributes.frontId ? attributes.frontId.S : 'unknown';
-
-    const isLive = attributes.stageName ? attributes.stageName.S === 'live' : false;
-    if (isLive && errorCount >= ERROR_THRESHOLD) {
-
-        dynamo.getItem({
-            TableName: ERRORS_TABLE_NAME,
-            Key: {
-                error: {
-                    S: error
-                }
-            }
-        }, (err, data) => {
-
-            if (err) {
-                logger.error('Error while fetching error item with message ', err);
-                callback();
-            }
-
-            if (data && data.Item) {
-
-                const lastSeen = new Date(parseInt(data.Item.lastSeen.N));
-                const lastSeenThreshold = new Date().setMinutes(today.getMinutes() - STALE_ERROR_THRESHOLD_MINUTES);
-                const errorIsStale = lastSeen.valueOf() < lastSeenThreshold;
-
-                let affectedFronts = new Set(data.Item.affectedFronts.SS);
-
-                if (errorIsStale) {
-                    affectedFronts = [frontId];
-                } else {
-                    const frontSet = new Set(data.Item.affectedFronts.SS);
-                    affectedFronts = Array.from(frontSet.add(frontId));
-                }
-
-                const updateErrorData = getErrorUpdateData (error, affectedFronts, today);
-                dynamo.updateItem(updateErrorData, (err) => {
-                    if (err) {
-                        logger.error('Error while fetching error item with message ', err);
-                        callback();
-                    } else {
-
-                        if (errorIsStale && isProd) {
-                            return sendAlert(attributes, frontId, errorCount, error, dynamo, post, logger)
-                            .then(callback)
-                            .catch(callback);
-                        } else {
-                            callback();
-                        }
-                    }
-                });
-          } else {
-
-              const newErrorData = getErrorCreateData (error, today, frontId);
-
-              dynamo.putItem(newErrorData, (err) => {
-                  if (err) {
-                      logger.error('Error while fetching error item with message ', err);
-                      callback();
-                  } else {
-                      if (isProd) {
-                          return sendAlert(attributes, frontId, errorCount, error, dynamo, post, logger)
-                          .then(callback)
-                          .catch(callback);
-                      } else {
-                          callback();
-                      }
-                  }
-              });
-          }
+  sts.assumeRole(
+    {
+      RoleArn: ROLE_TO_ASSUME,
+      RoleSessionName: "lambda-assume-role",
+      DurationSeconds: 900
+    },
+    (err, data) => {
+      if (err) {
+        console.error("Error assuming cross account role", err);
+        callback(err);
+      } else {
+        const stsCredentials = data.Credentials;
+        const assumedCredentials = new AWS.Credentials(
+          stsCredentials.AccessKeyId,
+          stsCredentials.SecretAccessKey,
+          stsCredentials.SessionToken
+        );
+        const dynamo = new AWS.DynamoDB({
+          credentials: assumedCredentials
         });
-    } else {
-      callback();
+        const lambda = new AWS.Lambda({
+          credentials: assumedCredentials
+        });
+        storeEvents({
+          event,
+          dynamo,
+          lambda,
+          isoDate: today.toISOString(),
+          logger: console,
+          callback,
+          isProd: STAGE === "PROD",
+          post: postUtil,
+          today: today
+        });
+      }
     }
+  );
 }
 
-function getErrorUpdateData (error, affectedFronts, today) {
-    return {
+export function storeEvents({
+  event,
+  callback,
+  dynamo,
+  isoDate,
+  logger,
+  post,
+  isProd,
+  today
+}) {
+  const jobs = { started: 0, completed: 0, total: event.Records.length };
+
+  mapLimit(
+    event.Records,
+    PARALLEL_JOBS,
+    (record, jobCallback) =>
+      putRecordToDynamo({
+        jobs,
+        record,
+        dynamo,
+        isoDate,
+        logger,
+        isProd,
+        callback: jobCallback,
+        post,
+        today
+      }),
+    err => {
+      if (err) {
+        logger.error("Error processing records", err);
+        callback(new Error("Error when processing records: " + err.message));
+      } else {
+        logger.log("DONE");
+        callback(null, "Processed " + event.Records.length + " records.");
+      }
+    }
+  );
+}
+
+function putRecordToDynamo({
+  jobs,
+  record,
+  dynamo,
+  isoDate,
+  isProd,
+  callback,
+  logger,
+  post,
+  today
+}) {
+  const jobId = ++jobs.started;
+
+  logger.log("Process job " + jobId + " in " + record.kinesis.sequenceNumber);
+
+  const buffer = new Buffer(record.kinesis.data, "base64");
+  const data = JSON.parse(buffer.toString("utf8"));
+  const action = {
+    SET: ["actionTime=:time", "statusCode=:status", "messageText=:message"]
+  };
+  if (data.status === "ok") {
+    action.SET.push("pressedTime=:time", "errorCount=:count");
+  } else {
+    action.ADD = ["errorCount :count"];
+  }
+  const updateExpression = Object.keys(action)
+    .map(key => `${key} ${action[key].join(", ")}`)
+    .join(" ");
+
+  dynamo.updateItem(
+    {
+      TableName: TABLE_NAME,
+      Key: {
+        stageName: {
+          S: data.isLive ? "live" : "draft"
+        },
+        frontId: {
+          S: data.front
+        }
+      },
+      UpdateExpression: updateExpression,
+      ExpressionAttributeValues: {
+        ":count": {
+          N: data.status === "ok" ? "0" : "1"
+        },
+        ":time": {
+          S: isoDate
+        },
+        ":status": {
+          S: data.status
+        },
+        ":message": {
+          S: data.message || data.status
+        }
+      },
+      ReturnValues: "ALL_NEW"
+    },
+    (err, updatedItem) => {
+      if (err) {
+        logger.error("Error while processing " + jobId, err);
+        callback(err);
+      } else {
+        maybeNotifyPressBroken({
+          item: updatedItem,
+          logger,
+          isProd,
+          post,
+          dynamo,
+          today,
+          callback
+        });
+      }
+    }
+  );
+}
+
+function maybeNotifyPressBroken({
+  item,
+  logger,
+  isProd,
+  post,
+  dynamo,
+  today,
+  callback
+}) {
+  const attributes = item ? item.Attributes : {};
+  const errorCount = attributes.errorCount
+    ? parseInt(item.Attributes.errorCount.N, 10)
+    : 0;
+  const error = errorParser.parse(
+    attributes.messageText ? attributes.messageText.S : "unknown error"
+  );
+  const frontId = attributes.frontId ? attributes.frontId.S : "unknown";
+
+  const isLive = attributes.stageName
+    ? attributes.stageName.S === "live"
+    : false;
+  if (isLive && errorCount >= ERROR_THRESHOLD) {
+    dynamo.getItem(
+      {
         TableName: ERRORS_TABLE_NAME,
         Key: {
-            error: {
-                S: error
+          error: {
+            S: error
+          }
+        }
+      },
+      (err, data) => {
+        if (err) {
+          logger.error("Error while fetching error item with message ", err);
+          callback();
+        }
+
+        if (data && data.Item) {
+          const lastSeen = new Date(parseInt(data.Item.lastSeen.N));
+          const lastSeenThreshold = new Date().setMinutes(
+            today.getMinutes() - STALE_ERROR_THRESHOLD_MINUTES
+          );
+          const errorIsStale = lastSeen.valueOf() < lastSeenThreshold;
+
+          let affectedFronts = new Set(data.Item.affectedFronts.SS);
+
+          if (errorIsStale) {
+            affectedFronts = [frontId];
+          } else {
+            const frontSet = new Set(data.Item.affectedFronts.SS);
+            affectedFronts = Array.from(frontSet.add(frontId));
+          }
+
+          const updateErrorData = getErrorUpdateData(
+            error,
+            affectedFronts,
+            today
+          );
+          dynamo.updateItem(updateErrorData, err => {
+            if (err) {
+              logger.error(
+                "Error while fetching error item with message ",
+                err
+              );
+              callback();
+            } else {
+              if (errorIsStale && isProd) {
+                return sendAlert(
+                  attributes,
+                  frontId,
+                  errorCount,
+                  error,
+                  dynamo,
+                  post,
+                  logger
+                )
+                  .then(callback)
+                  .catch(callback);
+              } else {
+                callback();
+              }
             }
+          });
+        } else {
+          const newErrorData = getErrorCreateData(error, today, frontId);
+
+          dynamo.putItem(newErrorData, err => {
+            if (err) {
+              logger.error(
+                "Error while fetching error item with message ",
+                err
+              );
+              callback();
+            } else {
+              if (isProd) {
+                return sendAlert(
+                  attributes,
+                  frontId,
+                  errorCount,
+                  error,
+                  dynamo,
+                  post,
+                  logger
+                )
+                  .then(callback)
+                  .catch(callback);
+              } else {
+                callback();
+              }
+            }
+          });
+        }
+      }
+    );
+  } else {
+    callback();
+  }
+}
+
+function getErrorUpdateData(error, affectedFronts, today) {
+  return {
+    TableName: ERRORS_TABLE_NAME,
+    Key: {
+      error: {
+        S: error
+      }
+    },
+    AttributeUpdates: {
+      lastSeen: {
+        Value: {
+          N: today.valueOf().toString()
         },
-        AttributeUpdates: {
-            lastSeen: {
-                Value: {
-                    N: today.valueOf().toString()
-                },
-                Action: 'PUT'
-            },
-            affectedFronts: {
-                Value: {
-                    SS: affectedFronts
-                },
-                Action: 'PUT'
-            }
-        }
-    };
+        Action: "PUT"
+      },
+      affectedFronts: {
+        Value: {
+          SS: affectedFronts
+        },
+        Action: "PUT"
+      }
+    }
+  };
 }
 
-function getErrorCreateData (error, today, frontId) {
-    const timeToLive = Math.floor(new Date().setHours(today.getHours() + TIME_TO_LIVE_HOURS).valueOf() / 1000);
-    return {
-        TableName: ERRORS_TABLE_NAME,
-        Item: {
-            error: {
-                S: error
-            },
-            ttl: {
-                N: timeToLive.toString()
-            },
-            lastSeen: {
-                N: today.valueOf().toString()
-            },
-            affectedFronts: {
-                SS: [frontId]
-            }
-        }
-    };
+function getErrorCreateData(error, today, frontId) {
+  const timeToLive = Math.floor(
+    new Date().setHours(today.getHours() + TIME_TO_LIVE_HOURS).valueOf() / 1000
+  );
+  return {
+    TableName: ERRORS_TABLE_NAME,
+    Item: {
+      error: {
+        S: error
+      },
+      ttl: {
+        N: timeToLive.toString()
+      },
+      lastSeen: {
+        N: today.valueOf().toString()
+      },
+      affectedFronts: {
+        SS: [frontId]
+      }
+    }
+  };
 }
 
-function sendAlert (attributes, frontId, errorCount, error, dynamo, post, logger) {
-
-  logger.log('Notifying pagerduty');
+function sendAlert(
+  attributes,
+  frontId,
+  errorCount,
+  error,
+  dynamo,
+  post,
+  logger
+) {
+  logger.log("Notifying pagerduty");
 
   return post({
-      url: 'https://events.pagerduty.com/generic/2010-04-15/create_event.json',
-      body: JSON.stringify({
-          // eslint-disable-next-line camelcase
-          service_key: config.pagerduty.key,
-          // eslint-disable-next-line camelcase
-          event_type: 'trigger',
-          // eslint-disable-next-line camelcase
-          incident_key: error.substring(0, MAX_INCIDENT_LENGTH),
-          description: `Front ${frontId} failed pressing`,
-          details: {
-              front: frontId,
-              stage: attributes.stageName ? attributes.stageName.S : 'unknown',
-              count: errorCount,
-              error: error
-          },
-          client: 'Press monitor',
-          // eslint-disable-next-line camelcase
-          client_url: `${config.facia[STAGE].path}/troubleshoot/stale/${frontId}`
-      })
+    url: "https://events.pagerduty.com/generic/2010-04-15/create_event.json",
+    body: JSON.stringify({
+      // eslint-disable-next-line camelcase
+      service_key: config.pagerduty.key,
+      // eslint-disable-next-line camelcase
+      event_type: "trigger",
+      // eslint-disable-next-line camelcase
+      incident_key: error.substring(0, MAX_INCIDENT_LENGTH),
+      description: `Front ${frontId} failed pressing`,
+      details: {
+        front: frontId,
+        stage: attributes.stageName ? attributes.stageName.S : "unknown",
+        count: errorCount,
+        error: error
+      },
+      client: "Press monitor",
+      // eslint-disable-next-line camelcase
+      client_url: `${config.facia[STAGE].path}/troubleshoot/stale/${frontId}`
+    })
   });
 }
-

--- a/lambda/util/errorParser.js
+++ b/lambda/util/errorParser.js
@@ -1,6 +1,6 @@
 module.exports = {
-    parse: function (error) {
-        const matchedError = error.match(/.+?(\))/);
-        return matchedError ? matchedError[0] : error;
-    }
+  parse: function(error) {
+    const matchedError = error.match(/.+?(\))/);
+    return matchedError ? matchedError[0] : error;
+  }
 };


### PR DESCRIPTION
To be merged after this PR: https://github.com/guardian/front-pressed-lambda/pull/9

In preparation for a bigger refactor, this change formats the lambda according to the rules defined in `.eslintrc`. This makes no change to the implementation.