### PR TITLE
Fix Riff-raff.yaml so that it deploys cms-fronts cloudformation template, plus add devx-backup-enabled = true tags for dynamo tables

### DIFF
--- a/cloudformation/cmsfronts.yml
+++ b/cloudformation/cmsfronts.yml
@@ -138,6 +138,9 @@ Resources:
             TimeToLiveSpecification:
                 AttributeName: ttl
                 Enabled: true
+            Tags:
+                - Key: devx-backup-enabled
+                  Value: true
 
     SendEmail:
         Type: AWS::IAM::Policy

--- a/cloudformation/cmsfronts.yml
+++ b/cloudformation/cmsfronts.yml
@@ -81,7 +81,7 @@ Resources:
                                     - ":"
                                     - Ref: "AWS::AccountId"
                                     - ":table/"
-                                    - Ref: MMTestFrontsErrorsDynamoDBTable
+                                    - Ref: FrontsErrorsDynamoDBTable
             Roles:
                 - Ref: AssumedRole
     DynamoDBTable:
@@ -112,10 +112,10 @@ Resources:
                         - StageMap
                         - Ref: Stage
                         - WriteThroughput
-    MMTestFrontsErrorsDynamoDBTable:
+    FrontsErrorsDynamoDBTable:
         Type: AWS::DynamoDB::Table
         Properties:
-            TableName: !Sub 'mm-test-front-pressed-lambda-errors-${Stage}'
+            TableName: !Sub 'front-pressed-lambda-errors-${Stage}'
             AttributeDefinitions:
                 -
                     AttributeName: error

--- a/cloudformation/cmsfronts.yml
+++ b/cloudformation/cmsfronts.yml
@@ -81,7 +81,7 @@ Resources:
                                     - ":"
                                     - Ref: "AWS::AccountId"
                                     - ":table/"
-                                    - Ref: FrontsErrorsDynamoDBTable
+                                    - Ref: MMTestFrontsErrorsDynamoDBTable
             Roles:
                 - Ref: AssumedRole
     DynamoDBTable:
@@ -112,10 +112,10 @@ Resources:
                         - StageMap
                         - Ref: Stage
                         - WriteThroughput
-    FrontsErrorsDynamoDBTable:
+    MMTestFrontsErrorsDynamoDBTable:
         Type: AWS::DynamoDB::Table
         Properties:
-            TableName: !Sub 'front-pressed-lambda-errors-${Stage}'
+            TableName: !Sub 'mm-test-front-pressed-lambda-errors-${Stage}'
             AttributeDefinitions:
                 -
                     AttributeName: error

--- a/package-lock.json
+++ b/package-lock.json
@@ -11290,8 +11290,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -14330,8 +14329,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "25.1.0",
@@ -17367,8 +17365,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
       "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "lambda/index.js",
   "version": "0.0.1",
   "license": "Apache-2.0",
-  "cloudformation": false,
+  "cloudformation": true,
   "buildDir": "tmp/lambda",
   "isAwsLambda": true,
   "riffraffFile": "./riff-raff.yaml",

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -18,18 +18,6 @@ deployments:
         PROD:
           filename: front-pressed-lambda.zip
           name: front-pressed-lambda-PROD-Lambda-12VCTV2MBIBW0
-  push-cms-fronts-template-to-s3:
-    type: aws-s3
-    regions:
-      - eu-west-1
-    stacks:
-      - cms-fronts
-    actions:
-      - uploadStaticFiles
-    parameters:
-      bucket: front-pressed-lambda
-      cacheControl: no-cache
-      publicReadAcl: false
   front-pressed-lambda-cms-fronts-template:
     type: cloud-formation
     regions:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,9 +1,13 @@
-regions: [eu-west-1]
-stacks: [frontend]
-
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   front-pressed-lambda:
     type: aws-lambda
+    regions:
+      - eu-west-1
+    stacks:
+      - frontend
     contentDirectory: front-pressed-lambda
     parameters:
       bucket: aws-front-pressed-lambda-dist
@@ -14,4 +18,23 @@ deployments:
         PROD:
           filename: front-pressed-lambda.zip
           name: front-pressed-lambda-PROD-Lambda-12VCTV2MBIBW0
-
+  push-cms-fronts-template-to-s3:
+    type: aws-s3
+    regions:
+      - eu-west-1
+    stacks:
+      - cms-fronts
+    actions:
+      - uploadStaticFiles
+    parameters:
+      bucket: front-pressed-lambda
+      cacheControl: no-cache
+      publicReadAcl: false
+  front-pressed-lambda-cms-fronts-template:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - cms-fronts
+    app: front-pressed-lambda
+    contentDirectory: cloudformation


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This change fixes riff-raff.yaml so that it actually deploys the cms-fronts.yaml cloudformation template. 

It also adds the devx-backup-enabled = true tag for the tables specified in the [Dynamo DB backup rollout plan](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit?usp=sharing)

These Dynamo tables are the ones deemed important enough by the owners of the CMS Fronts account to be worth backing up. The tables tagged in this change are:

front-pressed-lambda-errors-PROD
front-pressed-lambda-PROD-DynamoDBTable-M03VC0RYBQ1W

See [this trello card](https://trello.com/c/gTRWqbyU/2357-add-backup-tags-to-cloudformed-dynamodb-tables-cms-fronts-account) for details on the task.

See the [FAQ's on AWS-Backup](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit?usp=sharing) for more details.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

1) Obtain access to the appropriate aws account.

2) Deploy to CODE and confirm 'devx-backup-enabled' tag is added and set to 'true' for the 
front-pressed-lambda-errors-CODE
front-pressed-lambda-CODE-DynamoDBTable-M03VC0RYBQ1W
tables

3) Wait a day and navigate to aws-backup -> backup vaults -> devx-backup-vault 
and confirm backups are taken for these tables.

## How can we measure success?

From now on changes made to the cms-fronts cloudformation.yaml template will actually be deployed and will update the resources defined therein

## Have we considered potential risks?

For the changes to riff-raff.yaml, the main risks are:
1 - that deployment of the dynamo tables defined in the code will somehow lose the data (ulikely but will make backup copies of the tables before deploying just in case)
2 - That the tables have been modified by the console in the intervening time and deploying this cloudformation code will overwrite these configuration changes. This will be mitigated by taking backup copies and running drift detection after deployment.

For the introduction of the backup tag and ongoing backups of these tables, the main concern brought up is cost, however for most teams costs are negligible. See [cost modelling document](https://docs.google.com/document/d/1TSePpzZk6y2JrEOLvfwLzLxXmat725d0NldLdfjgo24/edit?usp=sharing) for details.

The only other risk is if you back something up to the vault that you wish to delete, you will not be able to - although the backup will auto-delete this record when it reaches the end of its life-cycle. Consider this scenario when choosing which tables to tag.

If you wish a particular table to have a shorter lifespan for its backups than the pre-defined life span (14 days) you can create a separate backup vault in aws-backup, but you will need to either define the tables for this separate vault by arn, use a different tag.

