### PR TITLE
Adding AWS Backup tag for front-pressed-lambda-errors Dynamo tables

### DIFF
--- a/cloudformation/cmsfronts.yml
+++ b/cloudformation/cmsfronts.yml
@@ -112,6 +112,9 @@ Resources:
                         - StageMap
                         - Ref: Stage
                         - WriteThroughput
+            Tags:
+                - Key: devx-backup-enabled
+                  Value: true
     FrontsErrorsDynamoDBTable:
         Type: AWS::DynamoDB::Table
         Properties:
@@ -138,6 +141,9 @@ Resources:
             TimeToLiveSpecification:
                 AttributeName: ttl
                 Enabled: true
+            Tags:
+                - Key: devx-backup-enabled
+                  Value: true
 
     SendEmail:
         Type: AWS::IAM::Policy


### PR DESCRIPTION
## What does this change?

This change adds the devx-backup-enabled = true tag for the front-pressed-lambda and front-pressed-lambda-errors table definition as it has been requested in the [Dynamo DB backup rollout plan](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit?usp=sharing)

This is one of the Dynamo tables deemed important enough by the owners of the CMS Fronts account to be worth backing up.

See [this trello card](https://trello.com/c/gTRWqbyU/2357-add-backup-tags-to-cloudformed-dynamodb-tables-cms-fronts-account) for details on the task.

See the [FAQ's on AWS-Backup](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit?usp=sharing) for more details.

## Deployment Note - in testing this I observed that the cloudformation template defined in this code does not actually get deployed when a deploy is run via riff-raff.
As such, to deploy this change, the template will need to be run as a change-set in the appropriate cloudformation stack.

## How to test

1) Deployed project front-pressed-lambda::cloudformation with this commit to CODE
2) Observed the changes to the front-pressed-lambda cloudformation looked correct
3) Use drift-detection to ensure the only change is the addition of the devx-backup-enabled tag.
4) Observed in the DynamoDB pages that the dev-x-backup-enabled tag had been added to the front-pressed-lambda-CODE-DynamoDBTable-1CY26GZDUP0OU and front-pressed-lambda-errors-CODE tables with the value set to true


## How can we measure success?

This will add protection for this table guarding against accidental or malicious loss or deletion of data

## Have we considered potential risks?

For the introduction of the backup tag and ongoing backups of these tables, the main concern brought up is cost, however for most teams costs are negligible. See [cost modelling document](https://docs.google.com/document/d/1TSePpzZk6y2JrEOLvfwLzLxXmat725d0NldLdfjgo24/edit?usp=sharing) for details.

The only other risk is if you back something up to the vault that you wish to delete, you will not be able to - although the backup will auto-delete this record when it reaches the end of its life-cycle. Consider this scenario when choosing which tables to tag.

If you wish a particular table to have a shorter lifespan for its backups than the pre-defined life span (14 days) you can create a separate backup vault in aws-backup, but you will need to either define the tables for this separate vault by arn, use a different tag.
