### PR TITLE
Deploy cms-fronts cloudformation via riff-raff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     permissions: # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
+      # Required for `guardian/actions-riff-raff`
+      pull-requests: write
 
     steps:
       # Seed the build number with last number from TeamCity.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,35 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - uses: guardian/actions-riff-raff@v2
-
+      - uses: guardian/actions-riff-raff@v3
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: front-pressed-lambda
           buildNumber: ${{ env.BUILD_NUMBER }}
           configPath: riff-raff.yaml
           contentDirectories: |
             front-pressed-lambda:
               - dist/front-pressed-lambda.zip
+
+      - uses: guardian/actions-riff-raff@v3
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: front-pressed-lambda::cloudformation
+          config: |
+            stacks:
+              - cms-fronts
+            regions:
+              - eu-west-1
+            allowedStages:
+              - CODE
+              - PROD
+            deployments:
+              cloudformation:
+                type: cloud-formation
+                app: front-pressed-lambda
+                parameters:
+                  templatePath: cmsfronts.yml
+                  createStackIfAbsent: false
+          contentDirectories: |
+            cloudformation:
+              - cloudformation/cmsfronts.yml


### PR DESCRIPTION
## What does this change?

Creates a new riff-raff project to deploy the cms-fronts cloudformation associated with this project. NB- the lambda runs in the frontend AWS account, and there is separate cloudformation for that which is still deployed manually.

Also bumps guardian/actions-riff-raff to v3

## How to deploy

* Manually tag existing cloudformation stacks are tagged with App/Stack/Stage
* Deploy to CODE using riff-raff
* Only changes should be additional tagging