### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/digital-cms


### PR DESCRIPTION
So it's clear who owns this repo, and to make it easier to add owners for review.
